### PR TITLE
Text::Requires -> Test::Requires	

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,7 +27,7 @@ requires(
 );
 test_requires(
     'Test::More'     => '0.98',
-    'Text::Requires' => 0,
+    'Test::Requires' => 0,
 );
 use_test_base;
 auto_include;


### PR DESCRIPTION
typo

```
$ cpanm -v git://github.com/dann/p5-plack-middleware-profiler-kytprof.git
...
==> Found dependencies: Text::Requires
Searching Text::Requires on cpanmetadb ...
! Finding Text::Requires on cpanmetadb failed.
Searching Text::Requires (0) on metacpan ...
! Could not find a release matching Text::Requires (0) on MetaCPAN.
Searching Text::Requires on mirror http://www.cpan.org ...
Downloading index file http://www.cpan.org/modules/02packages.details.txt.gz ...
! Finding Text::Requires (0) on mirror http://www.cpan.org failed.
! Couldn't find module or a distribution Text::Requires (0)
! Bailing out the installation for Plack-Middleware-Profiler-KYTProf-0.04. Retry with --prompt or --force.

$ cpanm --force git://github.com/kazuph/p5-plack-middleware-profiler-kytprof.git
Cloning git://github.com/kazuph/p5-plack-middleware-profiler-kytprof.git ... OK
--> Working on git://github.com/kazuph/p5-plack-middleware-profiler-kytprof.git
Configuring /private/var/folders/2t/9jdw26195l320p_j62rdmb2w0000gq/T/TEdgyOsjUT ... OK
Building and testing Plack-Middleware-Profiler-KYTProf-0.04 ... FAIL
! Testing Plack-Middleware-Profiler-KYTProf-0.04 failed but installing it anyway.
Successfully installed Plack-Middleware-Profiler-KYTProf-0.04
1 distribution installed
```
